### PR TITLE
Fix OpenGWAS API URL in DESCRIPTION

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -24,7 +24,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::covr
+          extra-packages: any::covr, any::xml2
           needs: coverage
 
       - name: Create and populate .Renviron file
@@ -39,7 +39,17 @@ jobs:
             clean = FALSE,
             install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package")
           )
+          covr::to_cobertura(cov)
         shell: Rscript {0}
+
+      - uses: codecov/codecov-action@v4
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          file: ./cobertura.xml
+          plugin: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Show testthat output
         if: always()

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -34,4 +34,4 @@ VignetteBuilder:
     knitr
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,7 @@ Authors@R: c(
     person("Rita", "Rasteiro", , "rita.rasteiro@bristol.ac.uk", role = "aut",
            comment = c(ORCID = "0000-0002-4217-3060"))
     )
-Description: Interface to the 'OpenGWAS' database API <https://gwas-api.mrcieu.ac.uk/>. Includes a wrapper
+Description: Interface to the 'OpenGWAS' database API <https://api.opengwas.io/api/>. Includes a wrapper
     to make generic calls to the API, plus convenience functions for
     specific queries.
 License: MIT + file LICENSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: ieugwasr
 Title: Interface to the 'OpenGWAS' Database API
-Version: 1.0.1
+Version: 1.0.2
 Authors@R: c(
     person("Gibran", "Hemani", , "g.hemani@bristol.ac.uk", role = c("aut", "cre", "cph"),
            comment = c(ORCID = "0000-0003-0920-1055")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# ieugwasr 1.0.2
+
 # ieugwasr 1.0.1
 
 * Checking for allowance depletion, and erroring until the allowance is reset

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # ieugwasr 1.0.2
 
+* Bump roxygen2 version
 # ieugwasr 1.0.1
 
 * Checking for allowance depletion, and erroring until the allowance is reset

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 # ieugwasr 1.0.2
 
 * Bump roxygen2 version
+* Update OpenGWAS API URL
+
 # ieugwasr 1.0.1
 
 * Checking for allowance depletion, and erroring until the allowance is reset

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,11 +1,12 @@
 url: https://mrcieu.github.io/ieugwasr/
 template:
   bootstrap: 5
+  light-switch: true
 
 navbar:
  structure:
     left:  [reference, articles, news]
-    right: [search, github]
+    right: [search, github, lightswitch]
  components:
   articles:
     text: Tutorials

--- a/ieugwasr.Rproj
+++ b/ieugwasr.Rproj
@@ -12,6 +12,8 @@ Encoding: UTF-8
 RnwWeave: Sweave
 LaTeX: pdfLaTeX
 
+AutoAppendNewline: Yes
+
 BuildType: Package
 PackageUseDevtools: Yes
 PackageInstallArgs: --no-multiarch --with-keep.source

--- a/man/ieugwasr-package.Rd
+++ b/man/ieugwasr-package.Rd
@@ -6,7 +6,7 @@
 \alias{ieugwasr-package}
 \title{ieugwasr: Interface to the 'OpenGWAS' Database API}
 \description{
-Interface to the 'OpenGWAS' database API \url{https://gwas-api.mrcieu.ac.uk/}. Includes a wrapper to make generic calls to the API, plus convenience functions for specific queries.
+Interface to the 'OpenGWAS' database API \url{https://api.opengwas.io/api/}. Includes a wrapper to make generic calls to the API, plus convenience functions for specific queries.
 }
 \seealso{
 Useful links:

--- a/tests/testthat/test_query.r
+++ b/tests/testthat/test_query.r
@@ -105,6 +105,7 @@ test_that("user", {
 
 	skip_on_cran()
 	skip_on_ci()
+	skip_if(Sys.getenv('OPENGWAS_X_TEST_MODE_KEY') != "")
 
 	# make sure valid jwt is in .Renviron
 	key <- get_opengwas_jwt()


### PR DESCRIPTION
I noticed the old API URL is in the DESCRIPTION file's Description field, and as a result appears prominently on the CRAN page <https://cran.r-project.org/package=ieugwasr>

![CleanShot 2024-08-21 at 14 33 22@2x](https://github.com/user-attachments/assets/c5a1b2e0-d7cd-4352-8f07-3878afa36961)

So this fixes that and 

* bumps roxygen2 version
* updates test-coverage GHA workflow
* adds a dark mode toggle to the pkgdown site with the new lightswitch option in pkgdown
* amendment to a test
* sets: ensure files end with a newline in RStudio project file
* bumps package version
